### PR TITLE
User can create a host profile - API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,9 +63,10 @@ GEM
       railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
-    devise_token_auth (1.1.0)
+    devise_token_auth (1.1.1)
+      bcrypt (~> 3.0)
       devise (> 3.5.2, < 4.7)
-      rails (>= 4.2.0, < 6)
+      rails (>= 4.2.0, < 6.1)
     diff-lcs (1.3)
     docile (1.3.2)
     erubi (1.8.0)
@@ -98,9 +99,9 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    msgpack (1.3.0)
+    msgpack (1.3.1)
     nio4r (2.4.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     pg (1.1.4)
@@ -133,7 +134,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.4)
+    rails-html-sanitizer (1.2.0)
       loofah (~> 2.2, >= 2.2.2)
     railties (5.2.3)
       actionpack (= 5.2.3)
@@ -166,7 +167,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
     ruby_dep (1.5.0)
-    shoulda-matchers (4.1.1)
+    shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -219,7 +220,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
 
 RUBY VERSION
-   ruby 2.4.1
+   ruby 2.4.1p111
 
 BUNDLED WITH
-   1.17
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,4 +223,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   2.0.1
+   1.17.0

--- a/app/controllers/api/v1/host_profiles_controller.rb
+++ b/app/controllers/api/v1/host_profiles_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::HostProfilesController < ApplicationController
+  
+  before_action :authenticate_api_v1_user!, only: [:create]
+
+
+  def create
+    
+  end
+
+  
+  private
+
+  def host_profile_params
+    params.permit( )
+  end
+
+end

--- a/app/controllers/api/v1/host_profiles_controller.rb
+++ b/app/controllers/api/v1/host_profiles_controller.rb
@@ -4,6 +4,13 @@ class Api::V1::HostProfilesController < ApplicationController
 
 
   def create
+    profile = HostProfile.create(host_profile_params)
+    
+    if profile.persisted?
+      render json: { message: 'Successfully created' }, status: 200
+    else
+      render json: { error: profile.errors.full_messages }, status: 422
+    end
     
   end
 
@@ -11,7 +18,7 @@ class Api::V1::HostProfilesController < ApplicationController
   private
 
   def host_profile_params
-    params.permit( )
+    params.permit(:description, :full_address, :price_per_day_1_cat, :supplement_price_per_cat_per_day, :max_cats_accepted, :availability, :lat, :long, :user_id)
   end
 
 end

--- a/app/controllers/host_profiles_controller.rb
+++ b/app/controllers/host_profiles_controller.rb
@@ -1,0 +1,2 @@
+class HostProfilesController < ApplicationController
+end

--- a/app/controllers/host_profiles_controller.rb
+++ b/app/controllers/host_profiles_controller.rb
@@ -1,2 +1,0 @@
-class HostProfilesController < ApplicationController
-end

--- a/app/models/host_profile.rb
+++ b/app/models/host_profile.rb
@@ -1,0 +1,3 @@
+class HostProfile < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/host_profile.rb
+++ b/app/models/host_profile.rb
@@ -1,3 +1,5 @@
 class HostProfile < ApplicationRecord
   belongs_to :user
+
+  validates_presence_of :description, :full_address, :price_per_day_1_cat, :supplement_price_per_cat_per_day, :max_cats_accepted, :availability, :lat, :long
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
 
   include DeviseTokenAuth::Concerns::User
+
+  has_one :host_profile, dependent: :delete
   
   validates :nickname, uniqueness: { case_sensitive: false }, presence: true
   validates :location, presence: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
     namespace :v1 do
       mount_devise_token_auth_for 'User', at: 'auth', skip: [:omniauth_callbacks]
+      resources :host_profiles, only: [:create]
     end
   end
 end

--- a/db/migrate/20190821164209_create_host_profiles.rb
+++ b/db/migrate/20190821164209_create_host_profiles.rb
@@ -1,0 +1,17 @@
+class CreateHostProfiles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :host_profiles do |t|
+      t.references :user, foreign_key: true
+      t.text :description
+      t.string :full_address
+      t.decimal :price_per_day_1_cat
+      t.decimal :supplement_price_per_cat_per_day
+      t.integer :max_cats_accepted
+      t.text :availability, array: true, default: []
+      t.decimal :lat
+      t.decimal :long
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_05_170419) do
+ActiveRecord::Schema.define(version: 2019_08_21_164209) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "host_profiles", force: :cascade do |t|
+    t.bigint "user_id"
+    t.text "description"
+    t.string "full_address"
+    t.decimal "price_per_day_1_cat"
+    t.decimal "supplement_price_per_cat_per_day"
+    t.integer "max_cats_accepted"
+    t.text "availability", default: [], array: true
+    t.decimal "lat"
+    t.decimal "long"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_host_profiles_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false
@@ -46,4 +61,5 @@ ActiveRecord::Schema.define(version: 2019_08_05_170419) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "host_profiles", "users"
 end

--- a/spec/factories/host_profiles.rb
+++ b/spec/factories/host_profiles.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :host_profile do
-    user { nil }
+    association :user
     description { "I am a man of constant sorrow and I love cats... I think" }
     full_address { "Kalamon 16, 2044, Strovolos, Nicosia, Cyprus" }
     price_per_day_1_cat { "100.35" }

--- a/spec/factories/host_profiles.rb
+++ b/spec/factories/host_profiles.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :host_profile do
+    user { nil }
+    description { "MyText" }
+    full_address { "MyString" }
+    price_per_day_1_cat { "9.99" }
+    supplement_price_per_cat_per_day { "9.99" }
+    max_cats_accepted { 1 }
+    availability { "MyText" }
+    lat { "9.99" }
+    long { "9.99" }
+  end
+end

--- a/spec/factories/host_profiles.rb
+++ b/spec/factories/host_profiles.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     price_per_day_1_cat { "100.35" }
     supplement_price_per_cat_per_day { "50.85" }
     max_cats_accepted { 3 }
-    availability { "[1560, 1561, 1562, 1563]" }
+    availability { [1560, 1561, 1562, 1563] }
     lat { "35.1018" }
     long { "33.38" }
   end

--- a/spec/factories/host_profiles.rb
+++ b/spec/factories/host_profiles.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :host_profile do
     user { nil }
-    description { "MyText" }
-    full_address { "MyString" }
-    price_per_day_1_cat { "9.99" }
-    supplement_price_per_cat_per_day { "9.99" }
-    max_cats_accepted { 1 }
-    availability { "MyText" }
-    lat { "9.99" }
-    long { "9.99" }
+    description { "I am a man of constant sorrow and I love cats... I think" }
+    full_address { "Kalamon 16, 2044, Strovolos, Nicosia, Cyprus" }
+    price_per_day_1_cat { "100.35" }
+    supplement_price_per_cat_per_day { "50.85" }
+    max_cats_accepted { 3 }
+    availability { "[1560, 1561, 1562, 1563]" }
+    lat { "35.1018" }
+    long { "33.38" }
   end
 end

--- a/spec/models/host_profile_spec.rb
+++ b/spec/models/host_profile_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe HostProfile, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/host_profile_spec.rb
+++ b/spec/models/host_profile_spec.rb
@@ -35,4 +35,15 @@ RSpec.describe HostProfile, type: :model do
       expect(HostProfile.last.availability.class).to eq Array
     end
   end
+
+  describe 'Delete dependent setting' do
+    it 'profile is deleted when associated user is deleted from the database' do
+      FactoryBot.create(:host_profile)
+      expect(HostProfile.all.length).to eq 1
+      expect(User.all.length).to eq 1
+      User.last.destroy
+      expect(HostProfile.all.length).to eq 0
+      expect(User.all.length).to eq 0
+    end
+  end
 end

--- a/spec/models/host_profile_spec.rb
+++ b/spec/models/host_profile_spec.rb
@@ -1,5 +1,31 @@
-require 'rails_helper'
-
 RSpec.describe HostProfile, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'should have valid Factory' do
+    expect(create(:host_profile)).to be_valid
+  end
+
+  describe 'Database table' do
+    it { is_expected.to have_db_column :description }
+    it { is_expected.to have_db_column :full_address }
+    it { is_expected.to have_db_column :price_per_day_1_cat }
+    it { is_expected.to have_db_column :supplement_price_per_cat_per_day }
+    it { is_expected.to have_db_column :max_cats_accepted }
+    it { is_expected.to have_db_column :availability }
+    it { is_expected.to have_db_column :lat }
+    it { is_expected.to have_db_column :long }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :description }
+    it { is_expected.to validate_presence_of :full_address }
+    it { is_expected.to validate_presence_of :price_per_day_1_cat }
+    it { is_expected.to validate_presence_of :supplement_price_per_cat_per_day }
+    it { is_expected.to validate_presence_of :max_cats_accepted }
+    it { is_expected.to validate_presence_of :availability }
+    it { is_expected.to validate_presence_of :lat }
+    it { is_expected.to validate_presence_of :long }
+  end
+
+  describe "Associations" do
+    it { is_expected.to belong_to(:user) }
+  end
 end

--- a/spec/models/host_profile_spec.rb
+++ b/spec/models/host_profile_spec.rb
@@ -25,7 +25,14 @@ RSpec.describe HostProfile, type: :model do
     it { is_expected.to validate_presence_of :long }
   end
 
-  describe "Associations" do
+  describe 'Associations' do
     it { is_expected.to belong_to(:user) }
+  end
+
+  describe 'Default values' do
+    it 'returns Array as class for availability field' do
+      FactoryBot.create(:host_profile)
+      expect(HostProfile.last.availability.class).to eq Array
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -63,4 +63,8 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "Relations" do
+    it { is_expected.to have_one(:host_profile) }
+  end
 end

--- a/spec/requests/api/v1/host_profiles/create_spec.rb
+++ b/spec/requests/api/v1/host_profiles/create_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe Api::V1::HostProfilesController, type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let(:credentials) { user.create_new_auth_token }
+  let(:headers) { { HTTP_ACCEPT: "application/json" }.merge!(credentials) }
+  let(:not_headers) { {HTTP_ACCEPT: "application/json"} }
+
+  describe "POST /api/v1/host_profile do
+
+    describe "successfully" do
+      before do
+        post "/api/v1/host_profile", params: {
+          description: 'Hello, I am the best, better than the rest!',
+          full_address: 'Solvarvsgatan 32, 41508, Göteborg, Sweden',
+          price_per_day_1_cat: '100',
+          supplement_price_per_cat_per_day: '35',
+          max_cats_accepted: 3,
+          availability: [1562803200000, 1562889600000, 1562976000000, 1563062400000, 1563148800000],
+          lat: '57.746517'
+          long: '12.028278'
+          user_id: user.id
+        }, 
+        headers: headers
+      end
+
+      it "creates a host profile" do
+        expect(json_response["message"]).to eq "Successfully created"
+        expect(response.status).to eq 200
+      end
+    end
+
+    describe "unsuccessfully" do
+      it "Host profile can not be created without all fields filled in" do
+        post "/api/v1/host_profile", params: {
+          description: '',
+          full_address: 'Solvarvsgatan 32, 41508, Göteborg, Sweden',
+          price_per_day_1_cat: '100',
+          supplement_price_per_cat_per_day: '35',
+          max_cats_accepted: 3,
+          availability: [1562803200000, 1562889600000, 1562976000000, 1563062400000, 1563148800000],
+          lat: '57.746517'
+          long: '12.028278'
+          user_id: user.id
+        }, 
+        headers: headers
+
+        expect(json_response['error']).to eq ["Description can't be blank"]
+        expect(response.status).to eq 422
+      end
+
+      it "Host profile can not be created if user is not logged in" do
+        post "/api/v1/host_profile", headers: not_headers
+        expect(json_response["errors"]).to eq ["You need to sign in or sign up before continuing."]
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/host_profiles/create_spec.rb
+++ b/spec/requests/api/v1/host_profiles/create_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
   let(:headers) { { HTTP_ACCEPT: "application/json" }.merge!(credentials) }
   let(:not_headers) { {HTTP_ACCEPT: "application/json"} }
 
-  describe "POST /api/v1/host_profile do
+  describe "POST /api/v1/host_profile" do
 
     describe "successfully" do
       before do
@@ -13,10 +13,10 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
           full_address: 'Solvarvsgatan 32, 41508, Göteborg, Sweden',
           price_per_day_1_cat: '100',
           supplement_price_per_cat_per_day: '35',
-          max_cats_accepted: 3,
+          max_cats_accepted: '3',
           availability: [1562803200000, 1562889600000, 1562976000000, 1563062400000, 1563148800000],
-          lat: '57.746517'
-          long: '12.028278'
+          lat: '57.746517',
+          long: '12.028278',
           user_id: user.id
         }, 
         headers: headers
@@ -35,10 +35,10 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
           full_address: 'Solvarvsgatan 32, 41508, Göteborg, Sweden',
           price_per_day_1_cat: '100',
           supplement_price_per_cat_per_day: '35',
-          max_cats_accepted: 3,
+          max_cats_accepted: '3',
           availability: [1562803200000, 1562889600000, 1562976000000, 1563062400000, 1563148800000],
-          lat: '57.746517'
-          long: '12.028278'
+          lat: '57.746517',
+          long: '12.028278',
           user_id: user.id
         }, 
         headers: headers

--- a/spec/requests/api/v1/host_profiles/create_spec.rb
+++ b/spec/requests/api/v1/host_profiles/create_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
   let(:headers) { { HTTP_ACCEPT: "application/json" }.merge!(credentials) }
   let(:not_headers) { {HTTP_ACCEPT: "application/json"} }
 
-  describe "POST /api/v1/host_profile" do
+  describe 'POST /api/v1/host_profile' do
 
-    describe "successfully" do
+    describe 'successfully' do
       before do
-        post "/api/v1/host_profile", params: {
+        post '/api/v1/host_profiles', params: {
           description: 'Hello, I am the best, better than the rest!',
           full_address: 'Solvarvsgatan 32, 41508, Göteborg, Sweden',
           price_per_day_1_cat: '100',
@@ -22,15 +22,15 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
         headers: headers
       end
 
-      it "creates a host profile" do
-        expect(json_response["message"]).to eq "Successfully created"
+      it 'creates a host profile' do
+        expect(json_response['message']).to eq 'Successfully created'
         expect(response.status).to eq 200
       end
     end
 
-    describe "unsuccessfully" do
-      it "Host profile can not be created without all fields filled in" do
-        post "/api/v1/host_profile", params: {
+    describe 'unsuccessfully' do
+      it 'Host profile can not be created without all fields filled in' do
+        post '/api/v1/host_profiles', params: {
           description: '',
           full_address: 'Solvarvsgatan 32, 41508, Göteborg, Sweden',
           price_per_day_1_cat: '100',
@@ -47,9 +47,9 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
         expect(response.status).to eq 422
       end
 
-      it "Host profile can not be created if user is not logged in" do
-        post "/api/v1/host_profile", headers: not_headers
-        expect(json_response["errors"]).to eq ["You need to sign in or sign up before continuing."]
+      it 'Host profile can not be created if user is not logged in' do
+        post '/api/v1/host_profiles', headers: not_headers
+        expect(json_response['errors']).to eq ['You need to sign in or sign up before continuing.']
       end
     end
   end

--- a/spec/requests/api/v1/host_profiles/create_spec.rb
+++ b/spec/requests/api/v1/host_profiles/create_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
           price_per_day_1_cat: '100',
           supplement_price_per_cat_per_day: '35',
           max_cats_accepted: '3',
-          availability: [1562803200000, 1562889600000, 1562976000000, 1563062400000, 1563148800000],
+          availability: '[1562803200000, 1562889600000, 1562976000000, 1563062400000, 1563148800000]',
           lat: '57.746517',
           long: '12.028278',
           user_id: user.id
@@ -36,7 +36,7 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
           price_per_day_1_cat: '100',
           supplement_price_per_cat_per_day: '35',
           max_cats_accepted: '3',
-          availability: [1562803200000, 1562889600000, 1562976000000, 1563062400000, 1563148800000],
+          availability: '[1562803200000, 1562889600000, 1562976000000, 1563062400000, 1563148800000]',
           lat: '57.746517',
           long: '12.028278',
           user_id: user.id


### PR DESCRIPTION
## [PT Story](https://www.pivotaltracker.com/story/show/167552979)

#### Changes proposed in this PR
* Creates request specs for `host_profile`
* Generates model with relevant fields, validations and associations
* Generates controller and writes `create` action
* Opens up route for `create` action only
* Addresses vulnerability of `nokogiri` gem following GitHub's alert