### PR TITLE
User can search among host profiles and view individual host profiles- API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'jbuilder', '~> 2.5'
 gem 'rack-cors', require: 'rack/cors'
 gem 'devise_token_auth'
+gem 'active_model_serializers', '~> 0.10.10'
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.2.3)
       activesupport (= 5.2.3)
       globalid (>= 0.3.6)
@@ -48,6 +53,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     coveralls (0.8.23)
@@ -83,6 +90,7 @@ GEM
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     json (2.2.0)
+    jsonapi-renderer (0.2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -202,6 +210,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.10)
   bootsnap (>= 1.1.0)
   coveralls
   devise_token_auth

--- a/app/controllers/api/v1/host_profiles_controller.rb
+++ b/app/controllers/api/v1/host_profiles_controller.rb
@@ -3,6 +3,9 @@ class Api::V1::HostProfilesController < ApplicationController
   before_action :authenticate_api_v1_user!, only: [:create, :destroy, :update]
 
 
+  def index
+  end
+  
   def create
     profile = HostProfile.create(host_profile_params)
     

--- a/app/controllers/api/v1/host_profiles_controller.rb
+++ b/app/controllers/api/v1/host_profiles_controller.rb
@@ -6,6 +6,8 @@ class Api::V1::HostProfilesController < ApplicationController
   def index
     if params[:user_id]
       profiles = HostProfile.where(user_id: params[:user_id])
+    elsif params[:location]
+      profiles = HostProfile.joins(:user).where(users: {location: params[:location]})
     else
       profiles = HostProfile.all
     end

--- a/app/controllers/api/v1/host_profiles_controller.rb
+++ b/app/controllers/api/v1/host_profiles_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::HostProfilesController < ApplicationController
   
-  before_action :authenticate_api_v1_user!, only: [:create, :destroy, :update]
+  before_action :authenticate_api_v1_user!, only: [:show, :create, :destroy, :update]
 
 
   def index
@@ -11,7 +11,11 @@ class Api::V1::HostProfilesController < ApplicationController
     end
       render json: profiles, each_serializer: HostProfiles::IndexSerializer
   end
-  
+
+  def show
+  end
+
+
   def create
     profile = HostProfile.create(host_profile_params)
     

--- a/app/controllers/api/v1/host_profiles_controller.rb
+++ b/app/controllers/api/v1/host_profiles_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::HostProfilesController < ApplicationController
     else
       profiles = HostProfile.all
     end
-      render json: { data: profiles }
+      render json: profiles, each_serializer: HostProfiles::IndexSerializer
   end
   
   def create

--- a/app/controllers/api/v1/host_profiles_controller.rb
+++ b/app/controllers/api/v1/host_profiles_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::HostProfilesController < ApplicationController
     elsif params[:location]
       profiles = HostProfile.joins(:user).where(users: {location: params[:location]})
     else
-      profiles = HostProfile.all
+      profiles = []
     end
       render json: profiles, each_serializer: HostProfiles::IndexSerializer
   end

--- a/app/controllers/api/v1/host_profiles_controller.rb
+++ b/app/controllers/api/v1/host_profiles_controller.rb
@@ -11,6 +11,7 @@ class Api::V1::HostProfilesController < ApplicationController
     end
       render json: profiles, each_serializer: HostProfiles::IndexSerializer
   end
+  
 
   def show
     profile = HostProfile.find(params[:id])

--- a/app/controllers/api/v1/host_profiles_controller.rb
+++ b/app/controllers/api/v1/host_profiles_controller.rb
@@ -13,6 +13,8 @@ class Api::V1::HostProfilesController < ApplicationController
   end
 
   def show
+    profile = HostProfile.find(params[:id])
+    render json: { data: profile }
   end
 
 

--- a/app/controllers/api/v1/host_profiles_controller.rb
+++ b/app/controllers/api/v1/host_profiles_controller.rb
@@ -46,7 +46,7 @@ class Api::V1::HostProfilesController < ApplicationController
   private
 
   def host_profile_params
-    params.permit(:description, :full_address, :price_per_day_1_cat, :supplement_price_per_cat_per_day, :max_cats_accepted, :availability, :lat, :long, :user_id)
+    params.permit(:description, :full_address, :price_per_day_1_cat, :supplement_price_per_cat_per_day, :max_cats_accepted, :availability, :lat, :long, :latitude, :longitude, :user_id)
   end
 
 end

--- a/app/controllers/api/v1/host_profiles_controller.rb
+++ b/app/controllers/api/v1/host_profiles_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::HostProfilesController < ApplicationController
 
   def show
     profile = HostProfile.find(params[:id])
-    render json: { data: profile }
+    render json: profile, serializer: HostProfiles::ShowSerializer
   end
 
 

--- a/app/controllers/api/v1/host_profiles_controller.rb
+++ b/app/controllers/api/v1/host_profiles_controller.rb
@@ -4,6 +4,12 @@ class Api::V1::HostProfilesController < ApplicationController
 
 
   def index
+    if params[:user_id]
+      profiles = HostProfile.where(user_id: params[:user_id])
+    else
+      profiles = HostProfile.all
+    end
+      render json: { data: profiles }
   end
   
   def create

--- a/app/models/host_profile.rb
+++ b/app/models/host_profile.rb
@@ -1,5 +1,5 @@
 class HostProfile < ApplicationRecord
   belongs_to :user
 
-  validates_presence_of :description, :full_address, :price_per_day_1_cat, :supplement_price_per_cat_per_day, :max_cats_accepted, :availability, :lat, :long
+  validates_presence_of :description, :full_address, :price_per_day_1_cat, :supplement_price_per_cat_per_day, :max_cats_accepted, :availability, :lat, :long, :latitude, :longitude
 end

--- a/app/serializers/host_profiles/index_serializer.rb
+++ b/app/serializers/host_profiles/index_serializer.rb
@@ -1,0 +1,7 @@
+class HostProfiles::IndexSerializer < ActiveModel::Serializer
+
+  attributes :id, :price_per_day_1_cat, :supplement_price_per_cat_per_day, :max_cats_accepted, :availability, :lat, :long
+  
+  belongs_to :user, serializer: Users::Serializer
+
+end

--- a/app/serializers/host_profiles/show_serializer.rb
+++ b/app/serializers/host_profiles/show_serializer.rb
@@ -1,0 +1,7 @@
+class HostProfiles::ShowSerializer < ActiveModel::Serializer
+
+  attributes :id, :description, :price_per_day_1_cat, :supplement_price_per_cat_per_day, :max_cats_accepted, :availability, :lat, :long
+  
+  belongs_to :user, serializer: Users::Serializer
+
+end

--- a/app/serializers/users/serializer.rb
+++ b/app/serializers/users/serializer.rb
@@ -1,0 +1,3 @@
+class Users::Serializer < ActiveModel::Serializer
+  attributes :id, :location, :nickname
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
     namespace :v1 do
       mount_devise_token_auth_for 'User', at: 'auth', skip: [:omniauth_callbacks]
-      resources :host_profiles, only: [:index, :create, :destroy, :update]
+      resources :host_profiles, only: [:index, :show, :create, :destroy, :update]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
     namespace :v1 do
       mount_devise_token_auth_for 'User', at: 'auth', skip: [:omniauth_callbacks]
-      resources :host_profiles, only: [:create, :destroy, :update]
+      resources :host_profiles, only: [:index, :create, :destroy, :update]
     end
   end
 end

--- a/db/migrate/20190824063135_add_coordinates_to_host_profiles.rb
+++ b/db/migrate/20190824063135_add_coordinates_to_host_profiles.rb
@@ -1,0 +1,6 @@
+class AddCoordinatesToHostProfiles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :host_profiles, :latitude, :decimal
+    add_column :host_profiles, :longitude, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_21_164209) do
+ActiveRecord::Schema.define(version: 2019_08_24_063135) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,8 @@ ActiveRecord::Schema.define(version: 2019_08_21_164209) do
     t.decimal "long"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.decimal "latitude"
+    t.decimal "longitude"
     t.index ["user_id"], name: "index_host_profiles_on_user_id"
   end
 

--- a/spec/factories/host_profiles.rb
+++ b/spec/factories/host_profiles.rb
@@ -9,5 +9,7 @@ FactoryBot.define do
     availability { [1560, 1561, 1562, 1563] }
     lat { "35.1018" }
     long { "33.38" }
+    latitude { "35.1018" }
+    longitude { "33.38" }
   end
 end

--- a/spec/models/host_profile_spec.rb
+++ b/spec/models/host_profile_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe HostProfile, type: :model do
     it { is_expected.to have_db_column :availability }
     it { is_expected.to have_db_column :lat }
     it { is_expected.to have_db_column :long }
+    it { is_expected.to have_db_column :latitude }
+    it { is_expected.to have_db_column :longitude }
   end
 
   describe 'Validations' do
@@ -23,6 +25,8 @@ RSpec.describe HostProfile, type: :model do
     it { is_expected.to validate_presence_of :availability }
     it { is_expected.to validate_presence_of :lat }
     it { is_expected.to validate_presence_of :long }
+    it { is_expected.to validate_presence_of :latitude }
+    it { is_expected.to validate_presence_of :longitude }
   end
 
   describe 'Associations' do

--- a/spec/requests/api/v1/host_profiles/create_spec.rb
+++ b/spec/requests/api/v1/host_profiles/create_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
           availability: '[1562803200000, 1562889600000, 1562976000000, 1563062400000, 1563148800000]',
           lat: '57.746517',
           long: '12.028278',
+          latitude: '57.746517',
+          longitude: '12.028278',
           user_id: user.id
         }, 
         headers: headers
@@ -39,6 +41,8 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
           availability: '[1562803200000, 1562889600000, 1562976000000, 1563062400000, 1563148800000]',
           lat: '57.746517',
           long: '12.028278',
+          latitude: '57.746517',
+          longitude: '12.028278',
           user_id: user.id
         }, 
         headers: headers

--- a/spec/requests/api/v1/host_profiles/index_spec.rb
+++ b/spec/requests/api/v1/host_profiles/index_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe Api::V1::HostProfilesController, type: :request do
+  let(:user) { FactoryBot.create(:user, email: 'chaos@thestreets.com', nickname: 'Joker') }
+  let(:another_user) { FactoryBot.create(:user, email: 'felix@craft.com', nickname: 'Planner') }
+  let(:headers) { { HTTP_ACCEPT: 'application/json' } }
+
+  describe 'GET /api/v1/host_profiles' do
+
+    before do
+      profile_user = FactoryBot.create(:host_profile, user_id: user.id)
+      profile_another_user = FactoryBot.create(:host_profile, user_id: another_user.id)
+    end
+
+    it 'returns a collection of host profiles' do
+      get '/api/v1/host_profiles', headers: headers
+      expect(json_response.count).to eq 2
+    end
+
+    it 'returns 200 response' do
+      get '/api/v1/host_profiles', headers: headers
+      expect(response.status).to eq 200
+    end
+    
+    it 'has correct keys in the response' do
+      get '/api/v1/host_profiles', headers: headers
+
+      profiles = HostProfile.all
+
+      profiles.each do |profile|
+        expect(json_response[profiles.index(profile)]).to include('id')
+        expect(json_response[profiles.index(profile)]).to include('price_per_day_1_cat')
+        expect(json_response[profiles.index(profile)]).to include('supplement_price_per_cat_per_day')
+        expect(json_response[profiles.index(profile)]).to include('max_cats_accepted')
+        expect(json_response[profiles.index(profile)]).to include('availability')
+        expect(json_response[profiles.index(profile)]).to include('lat')
+        expect(json_response[profiles.index(profile)]).to include('long')
+      end
+    end
+
+    describe 'for a specific user' do
+      
+      it "responds with specific user's host profile" do
+        get '/api/v1/host_profiles', params: {user_id: another_user.id} 
+        user_profile = HostProfile.where(user_id: another_user.id)
+        expect(json_response[user_profile]['user']['id']).to eq another_user.id
+        expect(json_response.count).to eq 1
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/host_profiles/index_spec.rb
+++ b/spec/requests/api/v1/host_profiles/index_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
 
     it 'returns a collection of host profiles' do
       get '/api/v1/host_profiles', headers: headers
+      binding.pry
       expect(json_response['data'].count).to eq 2
     end
 

--- a/spec/requests/api/v1/host_profiles/index_spec.rb
+++ b/spec/requests/api/v1/host_profiles/index_spec.rb
@@ -10,32 +10,15 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
       profile_another_user = FactoryBot.create(:host_profile, user_id: another_user.id)
     end
 
-    it 'returns a collection of host profiles' do
+    it 'does not return a collection of host profiles to protect user data' do
       get '/api/v1/host_profiles', headers: headers
-      expect(json_response.count).to eq 2
+      expect(json_response.count).to eq 0
+      expect(HostProfile.all.length).to eq 2
     end
 
     it 'returns 200 response' do
       get '/api/v1/host_profiles', headers: headers
       expect(response.status).to eq 200
-    end
-    
-    it 'has correct keys in the response' do
-      get '/api/v1/host_profiles', headers: headers
-
-      profiles = HostProfile.all
-
-      profiles.each do |profile|
-        expect(json_response[profiles.index(profile)]).to include('id')
-        expect(json_response[profiles.index(profile)]).to include('price_per_day_1_cat')
-        expect(json_response[profiles.index(profile)]).to include('supplement_price_per_cat_per_day')
-        expect(json_response[profiles.index(profile)]).to include('max_cats_accepted')
-        expect(json_response[profiles.index(profile)]).to include('availability')
-        expect(json_response[profiles.index(profile)]).to include('lat')
-        expect(json_response[profiles.index(profile)]).to include('long')
-        expect(json_response[profiles.index(profile)]).to include('user')
-        expect(json_response[profiles.index(profile)].count).to eq 8
-      end
     end
 
     describe 'for a specific user' do

--- a/spec/requests/api/v1/host_profiles/index_spec.rb
+++ b/spec/requests/api/v1/host_profiles/index_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
 
     it 'returns a collection of host profiles' do
       get '/api/v1/host_profiles', headers: headers
-      expect(json_response.count).to eq 2
+      expect(json_response['data'].count).to eq 2
     end
 
     it 'returns 200 response' do
@@ -39,9 +39,9 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
     describe 'for a specific user' do
       
       it "responds with specific user's host profile" do
-        get '/api/v1/host_profiles', params: {user_id: another_user.id} 
+        get '/api/v1/host_profiles', params: {user_id: another_user.id}
         user_profile = HostProfile.where(user_id: another_user.id)
-        expect(json_response[user_profile]['user']['id']).to eq another_user.id
+        expect(json_response['data'][0]['user_id']).to eq another_user.id
         expect(json_response.count).to eq 1
       end
     end

--- a/spec/requests/api/v1/host_profiles/index_spec.rb
+++ b/spec/requests/api/v1/host_profiles/index_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Api::V1::HostProfilesController, type: :request do
-  let(:user) { FactoryBot.create(:user, email: 'chaos@thestreets.com', nickname: 'Joker') }
-  let(:another_user) { FactoryBot.create(:user, email: 'felix@craft.com', nickname: 'Planner') }
+  let(:user) { FactoryBot.create(:user, email: 'chaos@thestreets.com', nickname: 'Joker', location: 'Athens') }
+  let(:another_user) { FactoryBot.create(:user, email: 'felix@craft.com', nickname: 'Planner', location: 'Crete') }
   let(:headers) { { HTTP_ACCEPT: 'application/json' } }
 
   describe 'GET /api/v1/host_profiles' do
@@ -42,8 +42,16 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
       
       it "responds with specific user's host profile" do
         get '/api/v1/host_profiles', params: {user_id: another_user.id}
-        user_profile = HostProfile.where(user_id: another_user.id)
         expect(json_response[0]['user']['id']).to eq another_user.id
+        expect(json_response.count).to eq 1
+      end
+    end
+
+    describe 'for a specific location' do
+      
+      it "responds with specific host profiles according to user's location" do
+        get '/api/v1/host_profiles', params: {location: another_user.location}
+        expect(json_response[0]['user']['location']).to eq another_user.location
         expect(json_response.count).to eq 1
       end
     end

--- a/spec/requests/api/v1/host_profiles/index_spec.rb
+++ b/spec/requests/api/v1/host_profiles/index_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
 
     it 'returns a collection of host profiles' do
       get '/api/v1/host_profiles', headers: headers
-      binding.pry
-      expect(json_response['data'].count).to eq 2
+      expect(json_response.count).to eq 2
     end
 
     it 'returns 200 response' do
@@ -27,13 +26,15 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
       profiles = HostProfile.all
 
       profiles.each do |profile|
-        expect(json_response['data'][profiles.index(profile)]).to include('id')
-        expect(json_response['data'][profiles.index(profile)]).to include('price_per_day_1_cat')
-        expect(json_response['data'][profiles.index(profile)]).to include('supplement_price_per_cat_per_day')
-        expect(json_response['data'][profiles.index(profile)]).to include('max_cats_accepted')
-        expect(json_response['data'][profiles.index(profile)]).to include('availability')
-        expect(json_response['data'][profiles.index(profile)]).to include('lat')
-        expect(json_response['data'][profiles.index(profile)]).to include('long')
+        expect(json_response[profiles.index(profile)]).to include('id')
+        expect(json_response[profiles.index(profile)]).to include('price_per_day_1_cat')
+        expect(json_response[profiles.index(profile)]).to include('supplement_price_per_cat_per_day')
+        expect(json_response[profiles.index(profile)]).to include('max_cats_accepted')
+        expect(json_response[profiles.index(profile)]).to include('availability')
+        expect(json_response[profiles.index(profile)]).to include('lat')
+        expect(json_response[profiles.index(profile)]).to include('long')
+        expect(json_response[profiles.index(profile)]).to include('user')
+        expect(json_response[profiles.index(profile)].count).to eq 8
       end
     end
 
@@ -42,7 +43,7 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
       it "responds with specific user's host profile" do
         get '/api/v1/host_profiles', params: {user_id: another_user.id}
         user_profile = HostProfile.where(user_id: another_user.id)
-        expect(json_response['data'][0]['user_id']).to eq another_user.id
+        expect(json_response[0]['user']['id']).to eq another_user.id
         expect(json_response.count).to eq 1
       end
     end

--- a/spec/requests/api/v1/host_profiles/index_spec.rb
+++ b/spec/requests/api/v1/host_profiles/index_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
       profiles = HostProfile.all
 
       profiles.each do |profile|
-        expect(json_response[profiles.index(profile)]).to include('id')
-        expect(json_response[profiles.index(profile)]).to include('price_per_day_1_cat')
-        expect(json_response[profiles.index(profile)]).to include('supplement_price_per_cat_per_day')
-        expect(json_response[profiles.index(profile)]).to include('max_cats_accepted')
-        expect(json_response[profiles.index(profile)]).to include('availability')
-        expect(json_response[profiles.index(profile)]).to include('lat')
-        expect(json_response[profiles.index(profile)]).to include('long')
+        expect(json_response['data'][profiles.index(profile)]).to include('id')
+        expect(json_response['data'][profiles.index(profile)]).to include('price_per_day_1_cat')
+        expect(json_response['data'][profiles.index(profile)]).to include('supplement_price_per_cat_per_day')
+        expect(json_response['data'][profiles.index(profile)]).to include('max_cats_accepted')
+        expect(json_response['data'][profiles.index(profile)]).to include('availability')
+        expect(json_response['data'][profiles.index(profile)]).to include('lat')
+        expect(json_response['data'][profiles.index(profile)]).to include('long')
       end
     end
 

--- a/spec/requests/api/v1/host_profiles/show_spec.rb
+++ b/spec/requests/api/v1/host_profiles/show_spec.rb
@@ -24,13 +24,47 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
       end
 
       it 'returns a success response' do
-        binding.pry
         expect(response.status).to eq 200
       end
 
       it 'returns a specific host profile' do
         profile = HostProfile.last
-        expect(json_response['data']['id']).to eq profile.id
+        expect(json_response['id']).to eq profile.id
+      end
+
+      it 'has correct keys in the response' do
+        expect(json_response).to include('id')
+        expect(json_response).to include('description')
+        expect(json_response).to include('price_per_day_1_cat')
+        expect(json_response).to include('supplement_price_per_cat_per_day')
+        expect(json_response).to include('max_cats_accepted')
+        expect(json_response).to include('availability')
+        expect(json_response).to include('lat')
+        expect(json_response).to include('long')
+        expect(json_response).to include('user')
+        expect(json_response.count).to eq 9
+        end
+      end
+
+      describe 'GET /api/v1/host_profiles/id' do
+        it 'requires user to be authenticated to see individual host profile' do
+          post '/api/v1/host_profiles', params: {
+            description: 'Hello, I am the best, better than the rest!',
+            full_address: 'Solvarvsgatan 32, 41508, Göteborg, Sweden',
+            price_per_day_1_cat: '100',
+            supplement_price_per_cat_per_day: '35',
+            max_cats_accepted: '3',
+            availability: '[1562803200000, 1562889600000, 1562976000000, 1563062400000, 1563148800000]',
+            lat: '57.746517',
+            long: '12.028278',
+            latitude: '57.746517',
+            longitude: '12.028278',
+            user_id: user.id
+          },
+          headers: headers
+          get "/api/v1/host_profiles/#{HostProfile.last.id}", headers: not_headers
+          expect(response.status).to eq 401
+          expect(json_response['errors']).to eq ['You need to sign in or sign up before continuing.']
+        end
       end
     end
-  end

--- a/spec/requests/api/v1/host_profiles/show_spec.rb
+++ b/spec/requests/api/v1/host_profiles/show_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Api::V1::HostProfilesController, type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let(:credentials) { user.create_new_auth_token }
+  let(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
+  let(:not_headers) { {HTTP_ACCEPT: 'application/json'} }
+    
+    describe 'GET /api/v1/host_profiles/id' do
+      before do
+        post '/api/v1/host_profiles', params: {
+          description: 'Hello, I am the best, better than the rest!',
+          full_address: 'Solvarvsgatan 32, 41508, Göteborg, Sweden',
+          price_per_day_1_cat: '100',
+          supplement_price_per_cat_per_day: '35',
+          max_cats_accepted: '3',
+          availability: '[1562803200000, 1562889600000, 1562976000000, 1563062400000, 1563148800000]',
+          lat: '57.746517',
+          long: '12.028278',
+          latitude: '57.746517',
+          longitude: '12.028278',
+          user_id: user.id
+        },
+        headers: headers
+        get "/api/v1/host_profiles/#{HostProfile.last.id}", headers: headers
+      end
+
+      it 'returns a success response' do
+        expect(response.status).to eq 200
+      end
+
+      it 'returns a specific host profile' do
+        profile = HostProfile.last
+        expect(json_response['id']).to eq profile.id
+      end
+    end
+  end

--- a/spec/requests/api/v1/host_profiles/show_spec.rb
+++ b/spec/requests/api/v1/host_profiles/show_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
       end
 
       it 'returns a success response' do
+        binding.pry
         expect(response.status).to eq 200
       end
 

--- a/spec/requests/api/v1/host_profiles/show_spec.rb
+++ b/spec/requests/api/v1/host_profiles/show_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Api::V1::HostProfilesController, type: :request do
 
       it 'returns a specific host profile' do
         profile = HostProfile.last
-        expect(json_response['id']).to eq profile.id
+        expect(json_response['data']['id']).to eq profile.id
       end
     end
   end


### PR DESCRIPTION
## [PT Story](https://www.pivotaltracker.com/story/show/168073562)

#### Changes proposed in this PR
* Adds 2 new coordinates fields in `host_profiles` model to make sure no sensitive user data are transferred over the internet
* Writes request spec for GET route
* Opens up `index` and `show` routes
* Creates `index` and `show` actions in controller
* Protects `show` action with authentication
* Installs `active-model-serializers` gem and serializes both `index` and `show` actions